### PR TITLE
fix: schema key names

### DIFF
--- a/schema/export/jdef.go
+++ b/schema/export/jdef.go
@@ -66,8 +66,7 @@ func FromProto(protoSchema *schema_j5pb.API) (*API, error) {
 			if err != nil {
 				return nil, err
 			}
-			fullKey := fmt.Sprintf("%s.%s", pkg.Name, key)
-			out.Schemas[fullKey] = schema
+			out.Schemas[key] = schema
 		}
 
 	}


### PR DESCRIPTION
I was seeing schemas come through with stutter in the key names, e.g.,

```
"o5.auth.v1.o5.auth.v1.Actor_NamedActor": {
      "properties": {
        "name": {
          "readOnly": false,
          "type": "string",
          "writeOnly": false
        }
      },
      "type": "object",
      "x-name": "Actor_NamedActor"
    }
```