### PR TITLE
fix: json reference path

### DIFF
--- a/schema/export/jdef.go
+++ b/schema/export/jdef.go
@@ -9,7 +9,7 @@ import (
 
 type API struct {
 	Packages []*Package            `json:"packages"`
-	Schemas  map[string]*Schema    `json:"schemas"`
+	Schemas  map[string]*Schema    `json:"definitions"`
 	Metadata *schema_j5pb.Metadata `json:"metadata"`
 }
 


### PR DESCRIPTION
The refs were pointing to: `#/definitions/x`, so I'm just updating the key schemas come through to ensure the JSON references are valid.