### PR TITLE
attempt to fix array validation in generated protos

### DIFF
--- a/internal/j5s/j5convert/convert_test.go
+++ b/internal/j5s/j5convert/convert_test.go
@@ -144,29 +144,51 @@ func TestSchemaToProto(t *testing.T) {
 				Def: &schema_j5pb.Object{
 					Name:        "Referenced",
 					Description: "Message Comment",
-					Properties: []*schema_j5pb.ObjectProperty{{
-						Name:        "field1",
-						Description: "Field Comment",
-						Schema: &schema_j5pb.Field{
-							Type: &schema_j5pb.Field_String_{
-								String_: &schema_j5pb.StringField{},
+					Properties: []*schema_j5pb.ObjectProperty{
+						{
+							Name:        "field1",
+							Description: "Field Comment",
+							Schema: &schema_j5pb.Field{
+								Type: &schema_j5pb.Field_String_{
+									String_: &schema_j5pb.StringField{},
+								},
 							},
 						},
-					}, {
-						Name: "enum",
-						Schema: &schema_j5pb.Field{
-							Type: &schema_j5pb.Field_Enum{
-								Enum: &schema_j5pb.EnumField{
-									Schema: &schema_j5pb.EnumField_Ref{
-										Ref: &schema_j5pb.Ref{
-											Package: "",
-											Schema:  "TestEnum",
+						{
+							Name: "enum",
+							Schema: &schema_j5pb.Field{
+								Type: &schema_j5pb.Field_Enum{
+									Enum: &schema_j5pb.EnumField{
+										Schema: &schema_j5pb.EnumField_Ref{
+											Ref: &schema_j5pb.Ref{
+												Package: "",
+												Schema:  "TestEnum",
+											},
 										},
 									},
 								},
 							},
 						},
-					}},
+						{
+							Name:        "array",
+							Description: "Field Comment",
+							Schema: &schema_j5pb.Field{
+								Type: &schema_j5pb.Field_Array{
+									Array: &schema_j5pb.ArrayField{
+										Items: &schema_j5pb.Field{
+											Type: &schema_j5pb.Field_String_{
+												String_: &schema_j5pb.StringField{
+													Rules: &schema_j5pb.StringField_Rules{
+														MinLength: proto.Uint64(1),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -177,13 +199,16 @@ func TestSchemaToProto(t *testing.T) {
 			Enum: &schema_j5pb.Enum{
 				Name:   "TestEnum",
 				Prefix: "TEST_ENUM_",
-				Options: []*schema_j5pb.Enum_Option{{
-					Name:   "UNSPECIFIED",
-					Number: 0,
-				}, {
-					Name:   "FOO",
-					Number: 1,
-				}},
+				Options: []*schema_j5pb.Enum_Option{
+					{
+						Name:   "UNSPECIFIED",
+						Number: 0,
+					},
+					{
+						Name:   "FOO",
+						Number: 1,
+					},
+				},
 			},
 		},
 	}
@@ -210,26 +235,49 @@ func TestSchemaToProto(t *testing.T) {
 		Package: proto.String("test.v1"),
 		MessageType: []*descriptorpb.DescriptorProto{{
 			Name: proto.String("Referenced"),
-			Field: []*descriptorpb.FieldDescriptorProto{{
-				Name:     proto.String("field_1"),
-				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
-				Number:   proto.Int32(1),
-				Options:  tEmptyTypeExt(t, "string"),
-				JsonName: proto.String("field1"),
-			}, {
-				Name:     proto.String("enum"),
-				Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
-				Number:   proto.Int32(2),
-				TypeName: proto.String(".test.v1.TestEnum"),
-				Options: withOption(tEmptyTypeExt(t, "enum"), validate.E_Field, &validate.FieldConstraints{
-					Type: &validate.FieldConstraints_Enum{
-						Enum: &validate.EnumRules{
-							DefinedOnly: gl.Ptr(true),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{
+					Name:     proto.String("field_1"),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					Number:   proto.Int32(1),
+					Options:  tEmptyTypeExt(t, "string"),
+					JsonName: proto.String("field1"),
+				},
+				{
+					Name:     proto.String("enum"),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_ENUM.Enum(),
+					Number:   proto.Int32(2),
+					TypeName: proto.String(".test.v1.TestEnum"),
+					Options: withOption(tEmptyTypeExt(t, "enum"), validate.E_Field, &validate.FieldConstraints{
+						Type: &validate.FieldConstraints_Enum{
+							Enum: &validate.EnumRules{
+								DefinedOnly: gl.Ptr(true),
+							},
 						},
-					},
-				}),
-				JsonName: proto.String("enum"),
-			}},
+					}),
+					JsonName: proto.String("enum"),
+				},
+				{
+					Name:   proto.String("array"),
+					Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					Label:  descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Number: proto.Int32(3),
+					Options: withOption(tEmptyTypeExt(t, "array"), validate.E_Field, &validate.FieldConstraints{
+						Type: &validate.FieldConstraints_Repeated{
+							Repeated: &validate.RepeatedRules{
+								Items: &validate.FieldConstraints{
+									Type: &validate.FieldConstraints_String_{
+										String_: &validate.StringRules{
+											MinLen: proto.Uint64(1),
+										},
+									},
+								},
+							},
+						},
+					}),
+					JsonName: proto.String("array"),
+				},
+			},
 			Options: emptyObjectOption,
 		}},
 		EnumType: []*descriptorpb.EnumDescriptorProto{{

--- a/internal/j5s/j5convert/fields.go
+++ b/internal/j5s/j5convert/fields.go
@@ -114,11 +114,9 @@ func buildProperty(ww *conversionVisitor, node *sourcewalk.PropertyNode) (*descr
 		var rules *validate.RepeatedRules
 		validateExt := proto.GetExtension(fieldDesc.Options, validate.E_Field).(*validate.FieldConstraints)
 		if validateExt != nil {
-			if rules == nil {
-				rules = &validate.RepeatedRules{}
+			rules = &validate.RepeatedRules{
+				Items: validateExt,
 			}
-
-			rules.Items = validateExt
 		}
 
 		if st.Array.Rules != nil {

--- a/internal/j5s/j5convert/fields.go
+++ b/internal/j5s/j5convert/fields.go
@@ -112,6 +112,10 @@ func buildProperty(ww *conversionVisitor, node *sourcewalk.PropertyNode) (*descr
 		ww.setJ5Ext(node.Source, fieldDesc.Options, "array", st.Array.Ext)
 
 		validateExt := proto.GetExtension(fieldDesc.Options, validate.E_Field).(*validate.FieldConstraints)
+
+		// Add validation rules based on the type of the array regardless of array
+		// rules being specified. This is specifically to cover cases where types
+		// are created from other primitives, like id62 having a string validation.
 		if validateExt != nil {
 			repeated := &validate.RepeatedRules{
 				Items: validateExt,

--- a/internal/j5s/j5convert/fields.go
+++ b/internal/j5s/j5convert/fields.go
@@ -111,32 +111,25 @@ func buildProperty(ww *conversionVisitor, node *sourcewalk.PropertyNode) (*descr
 
 		ww.setJ5Ext(node.Source, fieldDesc.Options, "array", st.Array.Ext)
 
-		var rules *validate.RepeatedRules
 		validateExt := proto.GetExtension(fieldDesc.Options, validate.E_Field).(*validate.FieldConstraints)
 		if validateExt != nil {
-			rules = &validate.RepeatedRules{
+			repeated := &validate.RepeatedRules{
 				Items: validateExt,
 			}
-		}
 
-		if st.Array.Rules != nil {
-			if rules == nil {
-				rules = &validate.RepeatedRules{}
+			if st.Array.Rules != nil {
+				repeated.MinItems = st.Array.Rules.MinItems
+				repeated.MaxItems = st.Array.Rules.MaxItems
+				repeated.Unique = st.Array.Rules.UniqueItems
 			}
 
-			rules.MinItems = st.Array.Rules.MinItems
-			rules.MaxItems = st.Array.Rules.MaxItems
-			rules.Unique = st.Array.Rules.UniqueItems
-		}
-
-		if rules != nil {
-			constraints := &validate.FieldConstraints{
+			rules := &validate.FieldConstraints{
 				Type: &validate.FieldConstraints_Repeated{
-					Repeated: rules,
+					Repeated: repeated,
 				},
 			}
 
-			proto.SetExtension(fieldDesc.Options, validate.E_Field, constraints)
+			proto.SetExtension(fieldDesc.Options, validate.E_Field, rules)
 			ww.file.ensureImport(bufValidateImport)
 		}
 

--- a/internal/j5s/j5parse/convert_lib_test.go
+++ b/internal/j5s/j5parse/convert_lib_test.go
@@ -192,6 +192,31 @@ func basicKey() *schema_j5pb.Field_Key {
 	}
 }
 
+func basicId62Key() *schema_j5pb.Field_Key {
+	return &schema_j5pb.Field_Key{
+		Key: &schema_j5pb.KeyField{
+			Format: &schema_j5pb.KeyFormat{
+				Type: &schema_j5pb.KeyFormat_Id62{
+					Id62: &schema_j5pb.KeyFormat_ID62{},
+				},
+			},
+		},
+	}
+}
+
+func basicArrayOf(itemSchema *schema_j5pb.Field, mod ...func(s *schema_j5pb.ArrayField)) *schema_j5pb.Field_Array {
+	base := &schema_j5pb.Field_Array{
+		Array: &schema_j5pb.ArrayField{
+			Items: itemSchema,
+		},
+	}
+	for _, m := range mod {
+		m(base.Array)
+	}
+
+	return base
+}
+
 func (f *fieldBuild) refObject(pkg string, name string) {
 	f.prop.Schema = &schema_j5pb.Field{
 		Type: &schema_j5pb.Field_Object{

--- a/internal/j5s/j5parse/convert_test.go
+++ b/internal/j5s/j5parse/convert_test.go
@@ -78,6 +78,20 @@ func TestObjectField(t *testing.T) {
 
 }
 
+func TestArrayObjectField(t *testing.T) {
+	file := build()
+	obj := file.addObject("FooListRequest")
+	fooIDs := obj.addField("foo_ids")
+	fooIDs.setSchema(basicArrayOf(&schema_j5pb.Field{Type: basicId62Key()}))
+	fooIDs.setRequired()
+
+	file.run(t, strings.Join([]string{
+		`object FooListRequest {`,
+		`  field foo_ids ! array:key:id62`,
+		`}`,
+	}, "\n"))
+}
+
 func TestEmptyOneofBody(t *testing.T) {
 
 	file := build()


### PR DESCRIPTION
**Problem:**
BCL code like this:

```hcl
object Request {
  field ids ! array:key:id62
}
```

Is currently outputting protos like this:
```proto
message Request {
  option (j5.ext.v1.message).object = {};
  
  repeated string ids = 1 [
    (buf.validate.field) = {
      required: true
      string: {
        pattern: "^[0-9A-Za-z]{22}$"
      }
    },
    (j5.ext.v1.field).array = {}
  ];
}
```

My understanding is that this should be:

```proto
message Request {
  option (j5.ext.v1.message).object = {};
  
  repeated string ids = 1 [
    (buf.validate.field) = {
      required: true,
      repeated: {
        items: {
          string: {
            pattern: "^[0-9A-Za-z]{22}$"
          }
        }
      }
    },
    (j5.ext.v1.field).array = {}
  ];
}
```

I believe this is causing issues when trying to use repeated keys and enums, for example. I am trying to fix this here.

I have tested this with j5s generate and it's giving me the output I expect.